### PR TITLE
Fix creating conf object when project name can not be inferred (issue…

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -3,7 +3,7 @@ import Conf from "conf";
 import delay from "delay";
 import { DiscoveredGateway, discoverGateway, TradfriClient } from "node-tradfri-client";
 
-const conf = new Conf();
+const conf = new Conf({projectName: "tradfri-cli"});
 
 async function getConnection(): Promise<TradfriClient> {
   console.log("Looking up IKEA Tradfri gateway on your network");


### PR DESCRIPTION
Bug fix proposal for the issue #18 I've posted. 

I've tested it, it works fine when the `projectName` is provided.